### PR TITLE
Fix expression deserialization

### DIFF
--- a/src/Extractor.Tests/Data/PartitionWithMultilineSourceExpression.json
+++ b/src/Extractor.Tests/Data/PartitionWithMultilineSourceExpression.json
@@ -1,0 +1,21 @@
+  {
+  "model": {
+    "tables": [
+      {
+        "name": "table1",
+        "partitions": [
+          {
+            "name": "table1-id",
+            "source": {
+              "type": "calculated",
+              "expression": [
+                "line1",
+                "line2"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/Extractor.Tests/ExtractTests.cs
+++ b/src/Extractor.Tests/ExtractTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -74,6 +75,24 @@ public sealed class Tests
                     fileName: "table1-id.calculated"
                 ),
                 content: "Row(\"Column\", BLANK())"
+            )
+        };
+
+        extracts.Should().BeEquivalentTo(expectedExtracts);
+    }
+    
+    [Test]
+    public void TestPartitionWithMultilineExpression()
+    {
+        var extracts = GetExtracts("PartitionWithMultilineSourceExpression.json");
+        var expectedExtracts = new List<Extract>
+        {
+            new Extract(
+                file: new File(
+                    relativePath: "tables/table1/partitions",
+                    fileName: "table1-id.calculated"
+                ),
+                content: "line1" + Environment.NewLine + "line2"
             )
         };
 

--- a/src/Extractor.Tests/Extractor.Tests.csproj
+++ b/src/Extractor.Tests/Extractor.Tests.csproj
@@ -23,6 +23,9 @@
       <None Update="Data\*.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="Data\PartitionWithMultilineSourceExpression.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/src/Extractor/Dto/ConcatenatingLineConverter.cs
+++ b/src/Extractor/Dto/ConcatenatingLineConverter.cs
@@ -26,7 +26,7 @@ public class ConcatenatingLineConverter : JsonConverter
             return string.Join("\n", values);
         }
 
-        throw new NotImplementedException($"The {nameof(ConcatenatingLineConverter)} expects string or array of strings in this context.");
+        throw new InvalidOperationException($"The {nameof(ConcatenatingLineConverter)} expects string or array of strings in this context.");
     }
     
     public override bool CanRead

--- a/src/Extractor/Dto/ConcatenatingLineConverter.cs
+++ b/src/Extractor/Dto/ConcatenatingLineConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Extractor.Dto;
+
+public class ConcatenatingLineConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.String)
+        {
+            return serializer.Deserialize(reader, objectType);
+        }
+        if (reader.TokenType == JsonToken.StartArray)
+        {
+            JArray array = JArray.Load(reader);
+            var values =  array.Select(t => t.Value<string>());
+            return string.Join("\n", values);
+        }
+
+        throw new NotImplementedException($"The {nameof(ConcatenatingLineConverter)} expects string or array of strings in this context.");
+    }
+    
+    public override bool CanRead
+    {
+        get { return true; }
+    }
+    
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert == typeof(string) || typeToConvert == typeof(List<string>);
+    }
+}

--- a/src/Extractor/Dto/ConcatenatingLineConverter.cs
+++ b/src/Extractor/Dto/ConcatenatingLineConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -29,13 +28,8 @@ public class ConcatenatingLineConverter : JsonConverter
         throw new InvalidOperationException($"The {nameof(ConcatenatingLineConverter)} expects string or array of strings in this context.");
     }
     
-    public override bool CanRead
-    {
-        get { return true; }
-    }
-    
     public override bool CanConvert(Type typeToConvert)
     {
-        return typeToConvert == typeof(string) || typeToConvert == typeof(List<string>);
+        return false;
     }
 }

--- a/src/Extractor/Dto/Dto.cs
+++ b/src/Extractor/Dto/Dto.cs
@@ -62,6 +62,7 @@ namespace Extractor.Dto
         public bool? IsNameInferred { get; set; }
         public bool? IsDataTypeInferred { get; set; }
         public string DataCategory { get; set; }
+        [JsonConverter(typeof(ConcatenatingLineConverter))]
         public string Expression { get; set; }
         public string SortByColumn { get; set; }
         public IList<Variation> Variations { get; set; }
@@ -108,6 +109,7 @@ namespace Extractor.Dto
     public sealed class Measure
     {
         public string Name { get; set; }
+        [JsonConverter(typeof(ConcatenatingLineConverter))]
         public string Expression { get; set; }
         public string FormatString { get; set; }
         public string DataType { get; set; }
@@ -195,6 +197,7 @@ namespace Extractor.Dto
     {
         public string Name { get; set; }
         public string Kind { get; set; }
+        [JsonConverter(typeof(ConcatenatingLineConverter))]
         [JsonProperty("Expression")]
         public string ExpressionContent { get; set; }
         public string LineageTag { get; set; }

--- a/src/Extractor/Dto/Dto.cs
+++ b/src/Extractor/Dto/Dto.cs
@@ -72,7 +72,6 @@ namespace Extractor.Dto
     public sealed class Source
     {
         public string Type { get; set; }
-        
         [JsonConverter(typeof(ConcatenatingLineConverter))]
         public string Expression { get; set; }
     }

--- a/src/Extractor/Dto/Dto.cs
+++ b/src/Extractor/Dto/Dto.cs
@@ -71,6 +71,8 @@ namespace Extractor.Dto
     public sealed class Source
     {
         public string Type { get; set; }
+        
+        [JsonConverter(typeof(ConcatenatingLineConverter))]
         public string Expression { get; set; }
     }
 


### PR DESCRIPTION
## Proposed changes

I fixed a change introduced in the September Power BI update. Before, each expression in the data model was saved as a string.
After the September update, each expression is stored as an array of strings.

The PR customizes JSON serializer to concatenate lines from an expression during deserialization.
For the older format (expression as a string), the serializer will return a string.
For the new format (expression a list of strings), the serializer will return a string created by concatenating the array of strings.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

I used the following solution to be backward compatible with existing format.